### PR TITLE
Taxonomy listings now linked to a faceted search.

### DIFF
--- a/website/templates/packages/package_detail.html
+++ b/website/templates/packages/package_detail.html
@@ -84,7 +84,7 @@
         <p>
             <strong>Taxonomy</strong><br />
             {% for tag in object.tags.all %}
-            <span class="label {% cycle 'label-success' 'label-info' 'label-inverse'%}"><a href="{% url 'haystack_search' %}?q={{tag}}">{{ tag }}</a></span>
+            <span class="label {% cycle 'label-success' 'label-info' 'label-inverse'%}"><a href="{% url "package_list" %}?q=&selected_facets=taxonomy_exact:{{tag|urlencode}}">{{ tag }}</a></span>
             {% endfor %}
         </p>
         {% endif %}

--- a/website/templates/projects/project_detail.html
+++ b/website/templates/projects/project_detail.html
@@ -76,7 +76,7 @@
         <p>
             <strong>Taxonomy</strong><br />
             {% for tag in tags %}
-            <span class="label {% cycle 'label-success' 'label-info' 'label-inverse'%}"><a href="{% url 'haystack_search' %}?q={{tag}}">{{ tag }}</a></span>
+            <span class="label {% cycle 'label-success' 'label-info' 'label-inverse'%}"><a href="{% url "project_list" %}?q=&selected_facets=taxonomy_exact:{{tag|urlencode}}">{{ tag }}</a></span>
             {% endfor %}
         </p>
         {% endif %}

--- a/website/templates/search/search.html
+++ b/website/templates/search/search.html
@@ -38,12 +38,15 @@
     <div class="well span3" id="refine-results">
         <h3>Refine Results</h3>
         <div id="reset-filters">
+            <br>
+            {% if filters %}
             <a href="#">Active Filters: </a><br>
             {% for filter, value in filters %}
                 {{ filter }}: {{ value }}<br>
             {% endfor %}
             <br>
             <a href="{{ request.path }}{% if query %}?q={{ query }}{% endif %}">Reset Filters</a>
+            {% endif %}
         </div>
         <ul class="nav nav-list">
         {% for field, facets in facets.fields.items %}


### PR DESCRIPTION
url for search has been updated to {% url "package(project)_list"
%}?q=&selected_facets=taxonomy_exact:{{tag|urlencode}}.
