### PR TITLE
Fixes #107 Form label for project tags

### DIFF
--- a/website/packages/forms.py
+++ b/website/packages/forms.py
@@ -11,7 +11,7 @@ class PackageCreateEditForm(forms.ModelForm):
             widget=forms.RadioSelect, choices=Package.PACKAGE_TYPES.items(),
             initial=Package.APPLICATION)
     tags = AutoCompleteSelectMultipleField(lookup_class=TaxonomyLookup,
-        required=False)
+        required=False, label='Taxonomy')
 
     class Meta:
         model = Package

--- a/website/projects/forms.py
+++ b/website/projects/forms.py
@@ -13,7 +13,7 @@ class ProjectCreateEditForm(forms.ModelForm):
     packages = AutoCompleteSelectMultipleField(lookup_class=PackageLookup,
         required=False)
     tags = AutoCompleteSelectMultipleField(lookup_class=TaxonomyLookup,
-        required=False)
+        required=False, label='Taxonomy')
     collaborators = AutoCompleteSelectMultipleField(lookup_class=UserLookup,
         required=False)
     num_users = forms.ChoiceField(choices=Project.NUM_USERS)


### PR DESCRIPTION
The word taxonomy is used across the project. I
removed the reference to 'tags' in both the project
form and the packge form.
