### PR TITLE
User documentation should point to "latest", not "develop"

### DIFF
--- a/website/templates/includes/footer.html
+++ b/website/templates/includes/footer.html
@@ -6,7 +6,7 @@
                 <li><a href="{% url "about" %}">About</a></li>
                 <li><a href="{% url "community" %}">Help</a></li>
                 <li><a href="https://pypi.python.org/pypi/RapidSMS/">Download</a></li>
-                <li><a href="http://rapidsms.readthedocs.org/en/develop/">Documentation</a></li>
+                <li><a href="http://rapidsms.readthedocs.org/en/latest/">Documentation</a></li>
             </ul>
             <p>&copy; Copyright 2013 - Site created by Caktus Group</p>
         </div>

--- a/website/templates/includes/navigation.html
+++ b/website/templates/includes/navigation.html
@@ -20,7 +20,7 @@
 
                     <li><a href="{% url "about" %}">About</a></li>
                     <li><a href="https://pypi.python.org/pypi/RapidSMS/"><i class="icon-external-link"></i> Download</a></li>
-                    <li><a href="http://rapidsms.readthedocs.org/en/develop/"><i class="icon-external-link"></i> Documentation</a></li>
+                    <li><a href="http://rapidsms.readthedocs.org/en/latest/"><i class="icon-external-link"></i> Documentation</a></li>
                     <li><a href="{% url "project_list" %}">Projects {% if pending_drafts %}<span class="badge badge-important">{{ pending_drafts }}</span>{% endif %}</a></li>
                     <li><a href="{% url "package_list" %}">Packages</a></li>
                     <li><a href="{% url "community" %}">Community</a></li>


### PR DESCRIPTION
There is another link to "develop" for ["how to contribute"](https://github.com/rapidsms/rapidsms.org/blob/e079113c9d9cad4151cb8aa2601e5336b8492d00/website/templates/website/community.html#L52), but I guess that is intended.
